### PR TITLE
Fix for Netlify continuous deployment pipeline.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  command = "npm run build"
   publish="build"
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
When deploying directly from GitHub, if Netlify is not instructed to run "npm run build", the deploy will fail. The environmental variables on Netlify will also need the REACT_APP_ prefix to work.