### PR TITLE
Stop React warnings causing Netlify build failure.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm run build"
+  command = "CI='' npm run build"
   publish="build"
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
Netlify changed their CI behaviour to treat all build warnings as errors, which will halt the deployment process if your React project has any warnings at all.
Adding CI='' allows the CI pipeline to ignore React project warnings.